### PR TITLE
修复在 EdgeOne Pages 环境下的后台部分跳转问题

### DIFF
--- a/edgeone.json
+++ b/edgeone.json
@@ -1,0 +1,14 @@
+{
+  "redirects": [
+    {
+      "source": "/settings",
+      "destination": "/settings/preferences",
+      "statusCode": 302
+    },
+    {
+      "source": "/admin",
+      "destination": "/admin/users",
+      "statusCode": 302
+    }
+  ]
+}


### PR DESCRIPTION
### 描述
通过 edgeone.json 修复了在 EdgeOne Pages 环境下部署时出现的后台部分按钮点击后跳转错误。

### 改动内容
- 新增 `edgeone.json` 配置文件。